### PR TITLE
manage roles for settings

### DIFF
--- a/includes/Api/ApiPricingPlan.php
+++ b/includes/Api/ApiPricingPlan.php
@@ -38,7 +38,7 @@ class ApiPricingPlan {
 		$wanted_plan       = $all_plans[ $wanted_plan_rank ]['stripe_code'];
 		$current_plan_rank = get_option( 'wubtitle_plan_rank' );
 		$is_upgrade        = $wanted_plan_rank > $current_plan_rank;
-		if ( ! isset( $_POST['_ajax_nonce'] ) || empty( $wanted_plan ) ) {
+		if ( ! isset( $_POST['_ajax_nonce'] ) || empty( $wanted_plan ) || ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'An error occurred. Please try again in a few minutes.', 'wubtitle' ) );
 		}
 		$nonce = sanitize_text_field( wp_unslash( $_POST['_ajax_nonce'] ) );
@@ -95,7 +95,7 @@ class ApiPricingPlan {
 	 * @return void
 	 */
 	public function reactivate_plan() {
-		if ( ! isset( $_POST['_ajax_nonce'] ) ) {
+		if ( ! isset( $_POST['_ajax_nonce'] ) || ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'An error occurred. Please try again in a few minutes.', 'wubtitle' ) );
 		}
 		$nonce = sanitize_text_field( wp_unslash( $_POST['_ajax_nonce'] ) );
@@ -242,7 +242,7 @@ class ApiPricingPlan {
 	 * @return void
 	 */
 	public function create_subscription() {
-		if ( ! isset( $_POST['_ajax_nonce'], $_POST['invoiceObject'], $_POST['email'], $_POST['actionCheckout'] ) ) {
+		if ( ! isset( $_POST['_ajax_nonce'], $_POST['invoiceObject'], $_POST['email'], $_POST['actionCheckout'] ) || ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'An error occurred. Please try again in a few minutes.', 'wubtitle' ) );
 		}
 		$action         = sanitize_text_field( wp_unslash( $_POST['actionCheckout'] ) );

--- a/includes/Dashboard/Settings.php
+++ b/includes/Dashboard/Settings.php
@@ -44,7 +44,7 @@ class Settings {
 	 */
 	public function create_settings_menu() {
 		// TODO: Cambiare $icon_url e $position (attualmente subito dopo "Impostazioni") quando verranno date indicazioni UX.
-		add_menu_page( __( 'Wubtitle Settings', 'wubtitle' ), __( 'Wubtitle', 'wubtitle' ), 'manage_options', 'wubtitle_settings', array( $this, 'render_settings_page' ), 'dashicons-format-status', 81 );
+		add_menu_page( __( 'Wubtitle Settings', 'wubtitle' ), __( 'Wubtitle', 'wubtitle' ), 'edit_posts', 'wubtitle_settings', array( $this, 'render_settings_page' ), 'dashicons-format-status', 81 );
 	}
 
 	/**
@@ -196,7 +196,7 @@ class Settings {
 	 * @return void
 	 */
 	private function render_plan_update( $cancelling ) {
-		if ( ! $cancelling && ! get_option( 'wubtitle_free' ) && $this->price_info_plans ) {
+		if ( ! $cancelling && ! get_option( 'wubtitle_free' ) && $this->price_info_plans && current_user_can( 'manage_options' ) ) {
 			?>
 			<a href="#" id="cancel-license-button" style="text-decoration: underline; color:red; margin-right:10px;" >
 				<?php esc_html_e( 'Unsubscribe', 'wubtitle' ); ?>
@@ -320,8 +320,16 @@ class Settings {
 		add_settings_section( 'wubtitle-main-settings', '', function(){}, 'wubtitle-settings' );
 
 		$plans    = get_option( 'wubtitle_all_plans', array() );
-		$disabled = count( $plans ) === 0 ? 'disabled' : '';
-		$message  = count( $plans ) === 0 ? __( 'Upgrade feature temporarily disabled due to error loading the page. Please refresh the page and try again.', 'wubtitle' ) : '';
+		$disabled = '';
+		$message  = '';
+		if ( count( $plans ) === 0 ) {
+			$disabled = 'disabled';
+			$message  = __( 'Upgrade feature temporarily disabled due to error loading the page. Please refresh the page and try again.', 'wubtitle' );
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			$disabled = 'disabled';
+			$message  = __( 'Upgrading and plan changes can only be done by the administrator', 'wubtitle' );
+		}
 		if ( count( $plans ) === 0 || ( get_option( 'wubtitle_plan_rank' ) < count( $plans ) - 1 && $this->price_info_plans ) ) {
 			add_settings_field(
 				'buy-license-button',
@@ -337,20 +345,22 @@ class Settings {
 				)
 			);
 		}
-		add_settings_field(
-			'wubtitle-license-key',
-			__( 'License Number', 'wubtitle' ),
-			array( $this, 'input_field' ),
-			'wubtitle-settings',
-			'wubtitle-main-settings',
-			array(
-				'type'        => 'text',
-				'name'        => 'wubtitle_license_key',
-				'placeholder' => __( 'License key', 'wubtitle' ),
-				'class'       => 'input-license-key',
-				'description' => __( 'Please enter the license key you received after successful checkout', 'wubtitle' ),
-			)
-		);
+		if ( current_user_can( 'manage_options' ) ) {
+			add_settings_field(
+				'wubtitle-license-key',
+				__( 'License Number', 'wubtitle' ),
+				array( $this, 'input_field' ),
+				'wubtitle-settings',
+				'wubtitle-main-settings',
+				array(
+					'type'        => 'text',
+					'name'        => 'wubtitle_license_key',
+					'placeholder' => __( 'License key', 'wubtitle' ),
+					'class'       => 'input-license-key',
+					'description' => __( 'Please enter the license key you received after successful checkout', 'wubtitle' ),
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/Utils/InvoiceHelper.php
+++ b/includes/Utils/InvoiceHelper.php
@@ -31,7 +31,7 @@ class InvoiceHelper {
 	 * @return void
 	 */
 	public function check_vat_code() {
-		if ( ! isset( $_POST['_ajax_nonce'], $_POST['price_plan'], $_POST['vat_code'], $_POST['country'] ) ) {
+		if ( ! isset( $_POST['_ajax_nonce'], $_POST['price_plan'], $_POST['vat_code'], $_POST['country'] ) || ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'An error occurred. Please try again in a few minutes.', 'wubtitle' ) );
 		}
 		$nonce        = sanitize_text_field( wp_unslash( $_POST['_ajax_nonce'] ) );
@@ -91,7 +91,7 @@ class InvoiceHelper {
 	 * @return void
 	 */
 	public function check_fiscal_code() {
-		if ( ! isset( $_POST['_ajax_nonce'], $_POST['fiscalCode'] ) ) {
+		if ( ! isset( $_POST['_ajax_nonce'], $_POST['fiscalCode'] ) || ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'An error occurred. Please try again in a few minutes.', 'wubtitle' ) );
 		}
 		$nonce       = sanitize_text_field( wp_unslash( $_POST['_ajax_nonce'] ) );
@@ -260,7 +260,7 @@ class InvoiceHelper {
 	 * @return void
 	 */
 	public function check_coupon() {
-		if ( ! isset( $_POST['_ajax_nonce'], $_POST['coupon'], $_POST['planId'] ) ) {
+		if ( ! isset( $_POST['_ajax_nonce'], $_POST['coupon'], $_POST['planId'] ) || ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'An error occurred. Please try again in a few minutes.', 'wubtitle' ) );
 		}
 		$coupon  = sanitize_text_field( wp_unslash( $_POST['coupon'] ) );


### PR DESCRIPTION
### All Submissions:

*   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
*   [x] Does your code has proper inline documentation? <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
added role management for settings
only the administrator can perform the update, the upgrade, the unsubscribe and the reactivate plan
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #320 .
