### PR TITLE
add wpversion and plugin version to activation call

### DIFF
--- a/includes/Core/Activation.php
+++ b/includes/Core/Activation.php
@@ -29,10 +29,13 @@ class Activation {
 	 */
 	public function wubtitle_activation_license_key() {
 		$site_url      = get_site_url();
+		$wubtitle_data = get_plugin_data( WUBTITLE_FILE_URL );
 		$body          = array(
 			'data' => array(
-				'domainUrl' => $site_url,
-				'siteLang'  => explode( '_', get_locale(), 2 )[0],
+				'domainUrl'     => $site_url,
+				'siteLang'      => explode( '_', get_locale(), 2 )[0],
+				'wpVersion'     => $GLOBALS['wp_version'],
+				'pluginVersion' => $wubtitle_data['Version'],
 			),
 		);
 		$response      = wp_remote_post(

--- a/includes/Core/Activation.php
+++ b/includes/Core/Activation.php
@@ -20,21 +20,24 @@ class Activation {
 	 */
 	public function run() {
 		register_activation_hook( WUBTITLE_FILE_URL, array( $this, 'wubtitle_activation_license_key' ) );
+		add_action( '_core_updated_successfully', array( $this, 'wubtitle_activation_license_key' ), 10, 1 );
 	}
 
 	/**
 	 * When the plugin is activated calls the endpoint to receive the license key.
 	 *
+	 * @param string $wp_version WordPress version.
+	 *
 	 * @return void
 	 */
-	public function wubtitle_activation_license_key() {
+	public function wubtitle_activation_license_key( $wp_version = '' ) {
 		$site_url      = get_site_url();
 		$wubtitle_data = get_plugin_data( WUBTITLE_FILE_URL );
 		$body          = array(
 			'data' => array(
 				'domainUrl'     => $site_url,
 				'siteLang'      => explode( '_', get_locale(), 2 )[0],
-				'wpVersion'     => $GLOBALS['wp_version'],
+				'wpVersion'     => empty( $wp_version ) ? $GLOBALS['wp_version'] : $wp_version,
 				'pluginVersion' => $wubtitle_data['Version'],
 			),
 		);


### PR DESCRIPTION
### All Submissions:

*   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
*   [x] Does your code has proper inline documentation? <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
upon activation it sends the plugin version and wpVersion to the aws endpoint
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
