### PR TITLE
fix activation plugin after upgrade

### DIFF
--- a/includes/Core/Activation.php
+++ b/includes/Core/Activation.php
@@ -21,6 +21,20 @@ class Activation {
 	public function run() {
 		register_activation_hook( WUBTITLE_FILE_URL, array( $this, 'wubtitle_activation_license_key' ) );
 		add_action( '_core_updated_successfully', array( $this, 'wubtitle_activation_license_key' ), 10, 1 );
+		add_filter( 'upgrader_post_install', array( $this, 'post_install' ), 10, 3 );
+	}
+
+	/**
+	 * After upgrade run plugin activation.
+	 *
+	 * @param array<mixed> ...$args installation result data.
+	 * @return void
+	 */
+	public function post_install( ...$args ) {
+		$name_plugin = $args[1]['plugin'];
+		if ( WUBTITLE_NAME . '/wubtitle.php' === $name_plugin ) {
+			$this->wubtitle_activation_license_key();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

*   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
*   [x] Does your code has proper inline documentation? <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

now activation is also performed after the plugin update