### PR TITLE
fix check vat call

### DIFF
--- a/src/stripe/UpdateForm.js
+++ b/src/stripe/UpdateForm.js
@@ -41,7 +41,7 @@ function App() {
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
-			body: `action=check_vat_code&_ajax_nonce=${ajaxNonce}&vat_code=${values.vat_code}&country=${values.country}&price_plan=${pricePlan}`,
+			body: `action=check_vat_code&_ajax_nonce=${ajaxNonce}&vat_code=${values.vat_code}&country=${values.country}&price_plan=${pricePlan}&companyName=${values.company_name}`,
 		})
 			.then((resp) => resp.json())
 			.then((response) => {


### PR DESCRIPTION
### All Submissions:

*   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
*   [x] Does your code has proper inline documentation? <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
add comapny name to check vat ajax call 