### PR TITLE
add timeout to job/create call

### DIFF
--- a/includes/Api/ApiRequest.php
+++ b/includes/Api/ApiRequest.php
@@ -186,6 +186,7 @@ class ApiRequest {
 			WUBTITLE_ENDPOINT . 'job/create',
 			array(
 				'method'  => 'POST',
+				'timeout' => 10,
 				'headers' => array(
 					'licenseKey'   => $license_key,
 					'domainUrl'    => get_option( 'siteurl' ),


### PR DESCRIPTION
### All Submissions:

*   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
*   [x] Does your code has proper inline documentation? <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add timeout 10 to job/create remote post